### PR TITLE
Fixed some bugs based on non-NULL-checking

### DIFF
--- a/db.c
+++ b/db.c
@@ -132,7 +132,7 @@ static const char *const args_docstring = {
 /* The switches program accepts. See https://tinyurl.com/argp-option-vectors */
 static struct argp_option args_parse_opts[] = {
  {"dir", 'd', "DIR", OPTION_ARG_OPTIONAL, "A directory containing DB files", 0},
- {"query", 'q', "QUERY", OPTION_ARG_OPTIONAL, "A query for DB. For sytax, see \"-q help\"", 0},
+ {"query", 'q', "QUERY", OPTION_ARG_OPTIONAL, "A query for DB. For syntax, see \"-q help\"", 0},
  {"gui", -1, 0, OPTION_ARG_OPTIONAL, "Run GUI instead of console", 0},
  {"quiet", 'Q', 0, OPTION_ARG_OPTIONAL, "Produce less output", 0},
  { 0 }	 /* Terminator. Required by argp */
@@ -255,7 +255,7 @@ int main(int argc, char *argv[]) {
 			struct strvec v;
 			if ((lerr = listdir(args.dir, &v)) != E_OK)
 				err_exit(args.isquiet, lerr);
-			printf("Lising keys in db:\n");
+			printf("Listing keys in db:\n");
 			unsigned long i;
 			for (i = 0; i < v.n; i++) {
 				printf(">>\t%s\n", v.vec[i]);

--- a/db.c
+++ b/db.c
@@ -291,6 +291,8 @@ int main(int argc, char *argv[]) {
 			free(fname);
 			break;
 		case Q_ADD:;
+			if ('\0' == *qval)
+				err_exit(args.isquiet, EM_QUERY);
 			struct dbitem item = make_item(qval);
 			char *fn = m_strjoin("/", args.dir, item.key);
 			if (NULL == fn)

--- a/db.c
+++ b/db.c
@@ -68,6 +68,7 @@ static char *query_name[] = {
 static struct dbitem make_item(const char *str)
 {
 	struct dbitem ret = {0};
+	if (str == NULL) return ret;
 	/* See expaination of how it works in main */
 	/* ord: last -> first -> email	*/
 	char *bkp, *ptr, *last_name, *first_name, *email, *date;
@@ -270,6 +271,8 @@ int main(int argc, char *argv[]) {
 			break;	
 		case Q_GET:;
 			char *fname = m_strjoin("/", args.dir, qval);
+			if (NULL == fname)
+				err_exit(args.isquiet, EM_QUERY);
 			struct dbitem itm;
 			if ((lerr = item_read(fname, &itm)) != E_OK) {
 				item_remove_bykey(qval, args.dir);
@@ -290,6 +293,8 @@ int main(int argc, char *argv[]) {
 		case Q_ADD:;
 			struct dbitem item = make_item(qval);
 			char *fn = m_strjoin("/", args.dir, item.key);
+			if (NULL == fn)
+				err_exit(args.isquiet, EM_QUERY);
 			if ((lerr = item_write(fn, &item)) != E_OK) {
 				free(fn);
 				err_exit(args.isquiet, lerr);

--- a/simpledb.c
+++ b/simpledb.c
@@ -115,13 +115,13 @@ enum err listdir(const char *dirname, struct strvec *vector)
 		goto cleanup_item_listdir;
 	}
 
-	vector->vec = malloc(n * sizeof *vector->vec);
+	if (NULL == (vector->vec = malloc(n * sizeof *vector->vec)))
+		errlevel = E_OSERR;
 	/* Copy contents to vec. If error occurs, stop copy and stick with what we have */
 	int i;
-	for (i = 0; i < n; i++) {
-		vector->vec[i] = strdup(namelist[i]->d_name);
-		if (vector->vec == NULL) break;
-	}
+	for (i = 0; i < n; i++)
+		if (NULL == (vector->vec[i] = strdup(namelist[i]->d_name)))
+			break;
 	vector->n = i;
 	if (i != n)
 		errlevel = E_OSERR;

--- a/simpledb.c
+++ b/simpledb.c
@@ -136,7 +136,7 @@ enum err listdir(const char *dirname, struct strvec *vector)
 
 FILE *xopen(const char *pathname, const char *mode)
 {
-	int fd = open(pathname, O_RDWR | O_CREAT, 0666);  /* "a+" + creation */
+	int fd = open(pathname, O_RDWR | O_CREAT, 0666);  /* "r+" + creation */
 	if (fd < 0)
 		return NULL;
 	return fdopen(fd, mode);

--- a/simpledb.c
+++ b/simpledb.c
@@ -66,6 +66,8 @@ enum err item_write(const char *pathname, struct dbitem *item)
 
 char *m_strjoin(const char *delimeter, const char *str1, const char *str2)
 {
+	if (NULL == str2 || NULL == str1 || NULL == delimeter)
+		return NULL;
 	unsigned long len = strlen(delimeter)+strlen(str1)+strlen(str2)+1;
 	char *res = malloc(MB_CUR_MAX * len * sizeof(*res));
 	if (NULL != res) {

--- a/simpledb.h
+++ b/simpledb.h
@@ -58,6 +58,4 @@ enum err listdir(const char *, struct strvec *);
  */
 char *m_strjoin(const char *, const char *, const char *);
 
-enum err item_remove_bykey(const char *, const char *);
-
 FILE *xopen(const char *, const char *);


### PR DESCRIPTION
Function _m_strjoin_ from simpledb.c doesn't now crash when any arg is NULL.
_-q "add "_ , _-q "add"_, _-q "get"_ now work without segfault or non-desirable behavior.