### PR TITLE
fixed bug with "./db -q add" or "./db -q add"

### DIFF
--- a/db.c
+++ b/db.c
@@ -300,7 +300,7 @@ int main(int argc, char *argv[]) {
 			if ((lerr = make_item(qval, item)) != E_OK) {
 				free(item);
 				err_exit(args.isquiet, lerr);
-			}			
+			}
 			char *fn = m_strjoin("/", args.dir, item->key);
 			if ((lerr = item_write(fn, item)) != E_OK) {
 				free(fn);

--- a/simpledb.c
+++ b/simpledb.c
@@ -127,6 +127,7 @@ enum err listdir(const char *dirname, struct strvec *vector)
 	cleanup_item_listdir:
 	while (n--)
 		free(namelist[n]);
+
 	free(namelist);
 	return errlevel;
 }

--- a/simpledb.c
+++ b/simpledb.c
@@ -125,9 +125,10 @@ enum err listdir(const char *dirname, struct strvec *vector)
 		errlevel = E_OSERR;
 
 	cleanup_item_listdir:
-	while (n--)
-		free(namelist[n]);
-
+	if(n > 0) {
+		while (n--)
+			free(namelist[n]);
+	}
 	free(namelist);
 	return errlevel;
 }


### PR DESCRIPTION
I finded the bug in the code. If we used:
**./db -q add** or **./db -q add**, we would have a _Segmentation fault_.
The reason of this is that the argument **const char \*str** of function *make_item()* can be a **NULL** pointer. In *make_item()* function you used to call *strdup(str)*. If the argument of *strdup()* function is a **NULL** pointer, you will have _Segmentation fault_.
To fix this I made next changes:
* I added new field to __enum main_err__ : __EM_NODATA__ and description for it to __static char *errmsg[]__  which means that _Error: Not avaiable data about person_.
* _make_item()_ now takes a pointer to _struct dbitem_ as second argument, instead of returning it
* _make_item()_ now returns _int_ value, in which means error code(enum main_err). This error code can be __EM_OK__(0) or __EM_NODATA__(12)
* after call _make_item()_ function I added checking on return value of this function.